### PR TITLE
VARL-233: Skills UI

### DIFF
--- a/CRM/Volunteer/Angular/Manager.php
+++ b/CRM/Volunteer/Angular/Manager.php
@@ -83,11 +83,17 @@ class VolunteerManager extends Manager {
 
       \CRM_Utils_Hook::angularModules($angularModules);
 
-      //Lets filter out unneeded modules
+      // Filter out modules which should not be loaded on Volunteer's base page
       foreach ($angularModules as $name => $module) {
-        //If the module doesn't request to be part of our page, and isn't a core module
-        // that we have included, remove it
-        if ((!array_key_exists("volunteer", $module) || !$module['volunteer']) && $module['ext'] != 'civicrm' && $module['ext'] != 'org.civicrm.angularprofiles') {
+        // Angular modules can register to be loaded by supplying a truthy
+        // property 'volunteer' as a sibling to 'ext' and 'js'
+        $moduleSelfRegisters = !empty($module['volunteer']);
+
+        // These extensions are always allowed. (Note: the modules associated
+        // with the civicrm "extension" are already filtered above.)
+        $whitelist = array('civicrm', 'org.civicrm.angularprofiles', 'org.civicrm.fieldmetadata',);
+
+        if (!$moduleSelfRegisters && !in_array($module['ext'], $whitelist)) {
           unset($angularModules[$name]);
         }
       }

--- a/ang/volunteer/Project.html
+++ b/ang/volunteer/Project.html
@@ -114,6 +114,9 @@
       </div>
     </fieldset>
 
+    <fieldset ng-repeat="customFieldGroup in supporting_data.project_custom_field_groups"
+              crm-render-field-collection="customFieldGroup" model="project"></fieldset>
+
     <fieldset class="crm-vol-relationships" ng-if="showRelationshipBlock" crm-ui-id-scope>
       <legend>{{ts("Relationships")}}</legend>
       <div ng-repeat="relType in relationship_types">

--- a/api/v3/VolunteerUtil.php
+++ b/api/v3/VolunteerUtil.php
@@ -164,6 +164,22 @@ function civicrm_api3_volunteer_util_getsupportingdata($params) {
     CRM_Volunteer_Hook::projectDefaultSettings($defaults);
 
     $results['defaults'] = $defaults;
+
+    $results['project_custom_field_groups'] = array();
+    $projectCustomFieldGroupResult = civicrm_api3('CustomGroup', 'get', array(
+      'extends' => 'Volunteer Project',
+      'is_active' => 1,
+      'return' => array('id'),
+      'sort' => 'weight',
+    ));
+    foreach ($projectCustomFieldGroupResult['values'] as $v) {
+      $meta = civicrm_api3('Fieldmetadata', 'get', array(
+        'entity' => "CustomGroup",
+        'entity_params' => array('id' => $v['id']),
+        'context' => "Angular",
+      ));
+      $results['project_custom_field_groups'][] = $meta['values'];
+    }
   }
 
   if ($controller === 'VolOppsCtrl') {


### PR DESCRIPTION
Adds support for custom fields in the project create/edit UI.

Caveats:
* It does not appear that widgets for all field types are supported yet, but this is probably an issue with org.civicrm.fieldmetadata. This may end up not being immediately relevant to VARL anyway, as I believe we're concerned with only one type.
* While scalar values are saved as expected, it appears that fields which allow selection of more than one value (e.g., checkboxes) will need extra help with processing. This also may not end up being immediately relevant.
* There is no support yet for preloading values. As a consequence, project creates will work as expected with regard to custom data, but project edits -- well, I'm not sure what to expect. I don't think this will be terribly hard -- some changes in the BAO, perhaps -- but I'm going for breadth rather than depth at the moment.