### PR TITLE
VARL-396 : Volunteer Button Behavior on Search.

### DIFF
--- a/ang/volunteer/AppealGrid.html
+++ b/ang/volunteer/AppealGrid.html
@@ -18,7 +18,7 @@
                <button ng-click="redirectTo(appeal.id)">
                   <i class="fa fa-chevron-circle-right" aria-hidden="true">{{ts('More Info')}}</i>
                </button>
-               <button><i class="fa fa-users" ng-click="volSignup(appeal.need_id,appeal.project_id)" aria-hidden="true">{{ts('Volunteer')}}</i></button>           
+               <button><i class="fa fa-users" ng-click="volSignup(appeal.need_id,appeal.project_id, appeal.display_volunteer_shift)" aria-hidden="true">{{ts('Volunteer')}}</i></button>
             </div>
          </div>
       </div>

--- a/ang/volunteer/AppealList.html
+++ b/ang/volunteer/AppealList.html
@@ -30,7 +30,7 @@
          </td>
          <td class="crm-vol-manage-beneficiaries"> 
             <button ng-click="redirectTo(appeal.id)"><i class="fa fa-chevron-circle-right" aria-hidden="true">{{ts('More Info')}}</i></button>
-            <button><i ng-click="volSignup(appeal.need_id,appeal.project_id)" class="fa fa-users" aria-hidden="true">{{ts('Volunteer')}}</i></button>
+            <button><i ng-click="volSignup(appeal.need_id,appeal.project_id, appeal.display_volunteer_shift)" class="fa fa-users" aria-hidden="true">{{ts('Volunteer')}}</i></button>
          </td>
       </tr>
    </tbody>

--- a/ang/volunteer/VolApplsCtrl.js
+++ b/ang/volunteer/VolApplsCtrl.js
@@ -151,11 +151,16 @@
       $window.location.href = $window.location.origin+Drupal.settings.basePath+"civicrm/vol/#/volunteer/appeal/"+appealId;
     }
 
-    $scope.volSignup= function(needId,projectId) {
-      if(needId) {
-        $window.location.href = $window.location.origin+Drupal.settings.basePath+"civicrm/volunteer/signup?reset=1&needs[]="+needId+"&dest=list";
-      } else {
+    $scope.volSignup= function(needId,projectId,display_volunteer_shift) {
+      if(display_volunteer_shift == "1") {
         $window.location.href = $window.location.origin+Drupal.settings.basePath+"civicrm/vol/#/volunteer/opportunities?project="+projectId+"&hideSearch=1";
+      } else {
+        if(needId) {
+          $window.location.href = $window.location.origin+Drupal.settings.basePath+"civicrm/volunteer/signup?reset=1&needs[]="+needId+"&dest=list";
+        }
+        else {
+          CRM.alert(ts('There are not any shifts for this project.'));
+        }
       }
     }
 


### PR DESCRIPTION
Handle below case for search appeal page.
(1) List Shifts: if the Appeal config is to show shifts - user is taken to #/volunteer/opportunities?project=n&hideSearch=1

(2) Sign-Up: if the Appeal config is to hide shifts  - user is taken straight to the sign-up form /civicrm/volunteer/signup?reset=1&needs[]=851&dest=list ( with the need-id of the flexible need of the project).